### PR TITLE
Add release to Sonatype action.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+# This workflow will release project to Sonatype.
+# For more information see: https://docs.github.com/en/actions/guides/publishing-java-packages-with-maven
+
+name: Publish to the Maven Central Repository
+
+on:
+  release:
+    types: [created]
+    
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:      
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+          token: ${{ secrets.PAT }}
+      - name: Configure Git User
+        run: |
+          git config user.name "johanhaleby"
+      - name: Set up Java and Maven Central Repository
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+          architecture: x64
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Release and deploy to Sonatype repo
+        run: mvn --batch-mode release:prepare release:perform -Dusername=johanhaleby -Dgoals=deploy -DdryRun=false -Dresume=false -DperformRelease=true '-Darguments=-DskipTests' -P release-sign-artifacts
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is a fork of the aspectj-maven-plugin that has Java 14 support.
+This is a fork of the aspectj-maven-plugin that has Java 16 support.
 
 Available in maven central:
 
@@ -6,7 +6,7 @@ Available in maven central:
 <dependency>
 	<groupId>se.haleby.aspectj</groupId>
 	<artifactId>aspectj-maven-plugin</artifactId>
-	<version>1.12.7</version>
+	<version>1.12.8</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -450,6 +450,12 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
+            <configuration>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
@johanhaleby, I did one change to make release to Sonatype could be automatical to reduce manual effort.

Below 5 secret items need to be configured in advance under _Settings->Secrets_:
**PAT**: Personal access token on Github
**OSSRH_USERNAME**: Your Sonatype username.
**OSSRH_TOKEN**: Your Sonatype token.
**MAVEN_GPG_PASSPHRASE**: Your GPG passphase
**MAVEN_GPG_PRIVATE_KEY**: Your GPG private key

Like I configued for another repo:
![image](https://user-images.githubusercontent.com/41132584/124414848-130e6a00-dd86-11eb-96f5-b2cfb222f0de.png)

Regarding how to expost GPG, please refer to below:
https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-Apache-Maven

After above preparation is ready, you could trigger deploying to Sonatype staging repo via "_Draft a new release_"